### PR TITLE
Add documentation of asset manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ And then execute:
 bundle
 ```
 
-If you are using asset pipeline, add the folloing lines to your `manifest.js`:
+If you are using asset pipeline, add the following lines to your `manifest.js`:
 
 ```js
 //= link administrate-field-jsonb/application.css

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ And then execute:
 bundle
 ```
 
+If you are using asset pipeline, add the folloing lines to your `manifest.js`:
+
+```js
+//= link administrate-field-jsonb/application.css
+//= link administrate-field-jsonb/application.js
+```
+
+The manifest file is at `app/assets/config` by default.
+
 ## Usage
 
 ```ruby


### PR DESCRIPTION
When I tried to install the plugin, I had an error of missing css and js in the manifest.
I updated the readme to cover it.