### PR TITLE
Make it JavaScript Turbolinks compatible

### DIFF
--- a/app/assets/javascripts/administrate-field-jsonb/components/accordion.js
+++ b/app/assets/javascripts/administrate-field-jsonb/components/accordion.js
@@ -1,5 +1,5 @@
-$(function () {
-  $(".administrate-field-jsonb-accordion").each(function () {
+$(document).on(typeof Turbolinks === 'undefined' ? 'ready' : 'turbolinks:load', function() {
+  $(".administrate-field-jsonb-accordion").each(function() {
     $(this).click(function() {
       $(this).toggleClass("administrate-field-jsonb-active").next().toggle();
     });

--- a/app/assets/javascripts/administrate-field-jsonb/components/editor.js
+++ b/app/assets/javascripts/administrate-field-jsonb/components/editor.js
@@ -1,6 +1,6 @@
-$(function () {
+$(document).on(typeof Turbolinks === 'undefined' ? 'ready' : 'turbolinks:load', function() {
   let editor, updatedJson;
-  $('.administrate-jsoneditor').each(function (index) {
+  $('.administrate-jsoneditor').each(function(index) {
 
     let $current = $(this).find("textarea");
 
@@ -14,7 +14,7 @@ $(function () {
 
         $current.val(JSON.stringify(updatedJson));
       },
-      onError: function (err) {
+      onError: function(err) {
         alert(err.toString());
       },
       navigationBar: false,

--- a/app/assets/javascripts/administrate-field-jsonb/components/viewer.js
+++ b/app/assets/javascripts/administrate-field-jsonb/components/viewer.js
@@ -1,4 +1,4 @@
-$(function () {
+$(document).on(typeof Turbolinks === 'undefined' ? 'ready' : 'turbolinks:load', function() {
   let viewer;
   $('.administrate-jsoneditor-viewer').each(function (index) {
 


### PR DESCRIPTION
I noticed that this project was only listening for jQuery's document ready events. When you use Turbolinks this event only gets triggered on full page reloads but not on subsequent page transitions. 

With this commit I add compatibility with Turbolinks (included with Rails by default)