### PR TITLE
Explicitly include jquery within the application.js package

### DIFF
--- a/app/assets/javascripts/administrate-field-jsonb/application.js
+++ b/app/assets/javascripts/administrate-field-jsonb/application.js
@@ -10,5 +10,7 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
+//= require jquery
+//= require jquery_ujs
 //= require jsoneditor-minimalist.min
 //= require_tree .


### PR DESCRIPTION
I'm using a version of Rails that doesn't include jquery by default, and I found that unless I explicitly included the jquery bundled within the Administrate engine within this field's `application.js`, the field didn't render in the browser (with an exception related to undefined `$`).

PR'ing my change in case it's useful to merge into the main release.

Thanks for a great gem!