### PR TITLE
Do not create more than one editor per input

### DIFF
--- a/app/assets/javascripts/administrate-field-jsonb/components/editor.js
+++ b/app/assets/javascripts/administrate-field-jsonb/components/editor.js
@@ -6,6 +6,9 @@
   $(document).on(eventName, function () {
     let editor, updatedJson;
     $('.administrate-jsoneditor').each(function (index) {
+      if ($(this).find(".jsoneditor").length > 0) {
+        return;
+      }
 
       let $current = $(this).find("textarea");
 

--- a/app/assets/javascripts/administrate-field-jsonb/components/viewer.js
+++ b/app/assets/javascripts/administrate-field-jsonb/components/viewer.js
@@ -6,6 +6,9 @@
   $(document).on(eventName, function () {
     let viewer;
     $('.administrate-jsoneditor-viewer').each(function (index) {
+      if ($(this).find(".jsoneditor").length > 0) {
+        return;
+      }
 
       let $current = $(this).find("textarea");
 


### PR DESCRIPTION
Handle being loaded via Turbo.

Currently in my app, the editor doubles every time the page is loaded via Turbo. This prevents that situation and doesn't seem to have any side-effects.