### PR TITLE
Adds support for administrate version 1.0

### DIFF
--- a/administrate-field-jsonb.gemspec
+++ b/administrate-field-jsonb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_runtime_dependency 'administrate', '< 1.0.0'
+  gem.add_runtime_dependency 'administrate', '< 2.0'
   gem.add_runtime_dependency 'rails', '>= 4.2'
 
   gem.add_development_dependency 'rspec', '~> 3.7'


### PR DESCRIPTION
Adds support for `administrate` [version 1.0](https://github.com/thoughtbot/administrate/blob/main/CHANGELOG.md#100-october-31-2025).

This just updates the gemspec to allow for any version of `administrate` < `2.0`.

Fixes https://github.com/codica2/administrate-field-jsonb/issues/31
